### PR TITLE
Implement UUID factory to prevent illegal reflective access

### DIFF
--- a/src/main/java/org/bbottema/loremipsumobjects/ClassBindings.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/ClassBindings.java
@@ -1,27 +1,13 @@
 package org.bbottema.loremipsumobjects;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.bbottema.loremipsumobjects.typefactories.ClassBasedFactory;
-import org.bbottema.loremipsumobjects.typefactories.ConstructorBasedFactory;
-import org.bbottema.loremipsumobjects.typefactories.LoremIpsumObjectFactory;
-import org.bbottema.loremipsumobjects.typefactories.MethodBasedFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomBigDecimalFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomBooleanFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomFactoryFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomOptionalFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomPrimitiveFactory;
-import org.bbottema.loremipsumobjects.typefactories.RandomStringFactory;
+import org.bbottema.loremipsumobjects.typefactories.*;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 import static org.bbottema.javareflection.ClassUtils.locateClass;
@@ -71,6 +57,7 @@ public class ClassBindings {
 		bind(Double.class, new RandomPrimitiveFactory<>(Double.TYPE));
 		bind(Number.class, new RandomFactoryFactory<Number>(Number.class, find(Long.TYPE), find(Integer.TYPE), find(Byte.TYPE), find(Short.TYPE), find(Double.TYPE), find(Float.TYPE)));
 		bind(String.class, new RandomStringFactory());
+		bind(UUID.class, new RandomUuidFactory());
 		bind(Boolean.class, new RandomBooleanFactory());
 		bind(List.class, new ClassBasedFactory<>(ArrayList.class));
 		bind(Map.class, new ClassBasedFactory<>(HashMap.class));

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomUuidFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomUuidFactory.java
@@ -1,0 +1,29 @@
+package org.bbottema.loremipsumobjects.typefactories;
+
+import org.bbottema.loremipsumobjects.ClassUsageInfo;
+import org.bbottema.loremipsumobjects.LoremIpsumConfig;
+import org.bbottema.loremipsumobjects.typefactories.util.LoremIpsumGenerator;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class RandomUuidFactory extends LoremIpsumObjectFactory<UUID> {
+
+    /**
+     * @param knownInstances   Not used.
+     * @param loremIpsumConfig Not used.
+     * @param exceptions       Not used.
+     * @return The result of {@link LoremIpsumGenerator#getRandomUuid()}.
+     */
+    @Override
+    public UUID _createLoremIpsumObject(
+            @Nullable final Type[] genericMetaData,
+            @Nullable final Map<String, ClassUsageInfo<?>> knownInstances,
+            LoremIpsumConfig loremIpsumConfig,
+            @Nullable final List<Exception> exceptions) {
+        return LoremIpsumGenerator.getInstance().getRandomUuid();
+    }
+}

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
@@ -3,6 +3,7 @@ package org.bbottema.loremipsumobjects.typefactories.util;
 import de.svenjacobs.loremipsum.LoremIpsum;
 
 import java.util.Random;
+import java.util.UUID;
 
 /**
  * Utility class that contains various methods to generate dummy data for primitive types.
@@ -25,6 +26,10 @@ public class LoremIpsumGenerator {
 
 	public boolean getRandomBoolean() {
 		return r.nextBoolean();
+	}
+
+	public UUID getRandomUuid() {
+		return UUID.randomUUID();
 	}
 
 	public int getRandomInt() {

--- a/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomUuidFactoryTest.java
+++ b/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomUuidFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Benny Bottema (benny@bennybottema.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bbottema.loremipsumobjects.typefactories;
+
+import org.bbottema.loremipsumobjects.LoremIpsumConfig;
+import org.bbottema.loremipsumobjects.typefactories.util.LoremIpsumGenerator;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RandomUuidFactoryTest {
+
+	@Test
+	public void testCreateLoremIpsumObject() {
+		final RandomUuidFactory factory = new RandomUuidFactory();
+
+		final LoremIpsumGenerator mock = mock(LoremIpsumGenerator.class);
+		LoremIpsumGenerator.setInstance(mock);
+		UUID uuid = UUID.randomUUID();
+		when(mock.getRandomUuid()).thenReturn(uuid);
+
+		assertThat(factory.createLoremIpsumObject(null, null, LoremIpsumConfig.builder().build(), null)).isEqualTo(uuid);
+
+		LoremIpsumGenerator.setInstance(new LoremIpsumGenerator());
+	}
+}


### PR DESCRIPTION
Generating a UUID leads to an illegal reflective access:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.bbottema.loremipsumobjects.typefactories.ConstructorBasedFactory (file:/Users/sm/.m2/repository/com/github/bbottema/lorem-ipsum-objects/4.0.0/lorem-ipsum-objects-4.0.0.jar) to constructor java.util.UUID(byte[])
WARNING: Please consider reporting this to the maintainers of org.bbottema.loremipsumobjects.typefactories.ConstructorBasedFactory
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Fix: Implement specific factory which calls UUID.randomUUID()