### PR TITLE
LocalDate illegal reflective access

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ classBindings.bind(Short.TYPE, new RandomPrimitiveFactory<>(Short.TYPE));
 classBindings.bind(Double.TYPE, new RandomPrimitiveFactory<>(Double.TYPE));
 classBindings.bind(String.class, new RandomStringFactory());
 classBindings.bind(Boolean.class, new RandomBooleanFactory());
+classBindings.bind(LocalDate.class, new RandomLocalDateFactory());
 
 classBindings.bind(List.class, new ClassBasedFactory<>(ArrayList.class));
 classBindings.bind(Map.class, new ClassBasedFactory<>(HashMap.class));

--- a/src/main/java/org/bbottema/loremipsumobjects/ClassBindings.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/ClassBindings.java
@@ -12,11 +12,13 @@ import org.bbottema.loremipsumobjects.typefactories.RandomOptionalFactory;
 import org.bbottema.loremipsumobjects.typefactories.RandomPrimitiveFactory;
 import org.bbottema.loremipsumobjects.typefactories.RandomStringFactory;
 import org.bbottema.loremipsumobjects.typefactories.RandomUuidFactory;
+import org.bbottema.loremipsumobjects.typefactories.RandomLocalDateFactory;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,6 +76,7 @@ public class ClassBindings {
 		bind(Number.class, new RandomFactoryFactory<Number>(Number.class, find(Long.TYPE), find(Integer.TYPE), find(Byte.TYPE), find(Short.TYPE), find(Double.TYPE), find(Float.TYPE)));
 		bind(String.class, new RandomStringFactory());
 		bind(UUID.class, new RandomUuidFactory());
+		bind(LocalDate.class, new RandomLocalDateFactory());
 		bind(Boolean.class, new RandomBooleanFactory());
 		bind(List.class, new ClassBasedFactory<>(ArrayList.class));
 		bind(Map.class, new ClassBasedFactory<>(HashMap.class));

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomLocalDateFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomLocalDateFactory.java
@@ -1,0 +1,29 @@
+package org.bbottema.loremipsumobjects.typefactories;
+
+import org.bbottema.loremipsumobjects.ClassUsageInfo;
+import org.bbottema.loremipsumobjects.LoremIpsumConfig;
+import org.bbottema.loremipsumobjects.typefactories.util.LoremIpsumGenerator;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public class RandomLocalDateFactory extends LoremIpsumObjectFactory<LocalDate> {
+
+    /**
+     * @param knownInstances   Not used.
+     * @param loremIpsumConfig Not used.
+     * @param exceptions       Not used.
+     * @return The result of {@link LoremIpsumGenerator#getRandomUuid()}.
+     */
+    @Override
+    public LocalDate _createLoremIpsumObject(
+            @Nullable final Type[] genericMetaData,
+            @Nullable final Map<String, ClassUsageInfo<?>> knownInstances,
+            LoremIpsumConfig loremIpsumConfig,
+            @Nullable final List<Exception> exceptions) {
+        return LoremIpsumGenerator.getInstance().getRandomLocalDate();
+    }
+}

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
@@ -2,8 +2,10 @@ package org.bbottema.loremipsumobjects.typefactories.util;
 
 import de.svenjacobs.loremipsum.LoremIpsum;
 
+import java.time.LocalDate;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Utility class that contains various methods to generate dummy data for primitive types.
@@ -13,7 +15,7 @@ public class LoremIpsumGenerator {
 	// we're using an instance here, so we can mock this instance in our junit tests
 	private static LoremIpsumGenerator instance = new LoremIpsumGenerator();
 
-	private final Random r = new Random();
+	private final ThreadLocalRandom r = ThreadLocalRandom.current();
 	private final LoremIpsum loremIpsum = new LoremIpsum();
 
 	public String getRandomString() {
@@ -30,6 +32,13 @@ public class LoremIpsumGenerator {
 
 	public UUID getRandomUuid() {
 		return UUID.randomUUID();
+	}
+
+	public LocalDate getRandomLocalDate() {
+		long minDay = LocalDate.of(1970, 1, 1).toEpochDay();
+		long maxDay = LocalDate.now().toEpochDay();
+		long randomDay = r.nextLong(minDay, maxDay);
+		return LocalDate.ofEpochDay(randomDay);
 	}
 
 	public int getRandomInt() {

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/util/LoremIpsumGenerator.java
@@ -3,7 +3,6 @@ package org.bbottema.loremipsumobjects.typefactories.util;
 import de.svenjacobs.loremipsum.LoremIpsum;
 
 import java.time.LocalDate;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomLocalDateFactoryTest.java
+++ b/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomLocalDateFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Benny Bottema (benny@bennybottema.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bbottema.loremipsumobjects.typefactories;
+
+import org.bbottema.loremipsumobjects.LoremIpsumConfig;
+import org.bbottema.loremipsumobjects.typefactories.util.LoremIpsumGenerator;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RandomLocalDateFactoryTest {
+
+    @Test
+    public void testCreateLoremIpsumObject() {
+        final RandomLocalDateFactory factory = new RandomLocalDateFactory();
+
+        final LoremIpsumGenerator mock = mock(LoremIpsumGenerator.class);
+        LoremIpsumGenerator.setInstance(mock);
+        LocalDate localDate = LocalDate.now();
+        when(mock.getRandomLocalDate()).thenReturn(localDate);
+
+        assertThat(factory.createLoremIpsumObject(null, null, LoremIpsumConfig.builder().build(), null)).isEqualTo(localDate);
+
+        LoremIpsumGenerator.setInstance(new LoremIpsumGenerator());
+    }
+}


### PR DESCRIPTION
Generating a LocalDate leads to an illegal reflective access:
```
WARNING: An illegal reflective access operation has occurred
```
Fix: Implement specific factory which calls LoremIpsumGenerator.getRandomLocalDate()

