### PR TITLE
 fix issue #19

### DIFF
--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
@@ -76,7 +76,7 @@ public abstract class LoremIpsumObjectFactory<T> {
 	}
 
 	@Nullable
-	abstract T _createLoremIpsumObject(
+	public abstract T _createLoremIpsumObject(
 			@Nullable Type[] genericMetaData,
 			@Nullable Map<String, ClassUsageInfo<?>> knownInstances,
 			LoremIpsumConfig loremIpsumConfig,

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomEnumFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomEnumFactory.java
@@ -30,6 +30,6 @@ public class RandomEnumFactory<T extends Enum<?>> extends LoremIpsumObjectFactor
 			LoremIpsumConfig loremIpsumConfig,
 			@Nullable final List<Exception> exceptions) {
 		final T[] enums = clazz.getEnumConstants();
-		return enums[LoremIpsumGenerator.getInstance().getRandomInt(enums.length - 1)];
+		return enums[LoremIpsumGenerator.getInstance().getRandomInt(enums.length)];
 	}
 }

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomFactoryFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomFactoryFactory.java
@@ -29,7 +29,7 @@ public class RandomFactoryFactory<T> extends LoremIpsumObjectFactory<T> {
 	@Nullable
 	@Override
 	@SuppressWarnings("unchecked")
-	T _createLoremIpsumObject(@Nullable Type[] genericMetaData, @Nullable Map<String, ClassUsageInfo<?>> knownInstances, LoremIpsumConfig loremIpsumConfig, @Nullable List<Exception> exceptions) {
+	public T _createLoremIpsumObject(@Nullable Type[] genericMetaData, @Nullable Map<String, ClassUsageInfo<?>> knownInstances, LoremIpsumConfig loremIpsumConfig, @Nullable List<Exception> exceptions) {
 		return (T) factories.get(RANDOM.nextInt(factories.size()))
 				.createLoremIpsumObject(genericMetaData, knownInstances, loremIpsumConfig, exceptions);
 	}

--- a/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomEnumFactoryTest.java
+++ b/src/test/java/org/bbottema/loremipsumobjects/typefactories/RandomEnumFactoryTest.java
@@ -28,7 +28,7 @@ public class RandomEnumFactoryTest {
 
 	@Test
 	public void testCreateLoremIpsumObject() {
-		when(mock.getRandomInt(Visibility.values().length - 1))
+		when(mock.getRandomInt(Visibility.values().length))
 				.thenReturn(Visibility.DEFAULT.ordinal())
 				.thenReturn(Visibility.PRIVATE.ordinal())
 				.thenReturn(Visibility.PROTECTED.ordinal())


### PR DESCRIPTION
When i Have an Enum with One value I got this error
```
ERROR org.bbottema.loremipsumobjects.typefactories.ClassBasedFactory - error logged:
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.concurrent.ThreadLocalRandom.nextInt(ThreadLocalRandom.java:310)
```
Yes There is always a solution by using ClassBindings for my specific enum like
```java
result.bind(SingleTypeEnum.class, new FixedInstanceFactory<>(SingleTypeEnum.TYPE1));
```

Also: make possible to create own Object Factory to overload public method