### PR TITLE
I would suggest to make _createLoremIpsumObject public accessible

### DIFF
--- a/src/main/java/org/bbottema/loremipsumobjects/LoremIpsumConfig.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/LoremIpsumConfig.java
@@ -11,5 +11,6 @@ import lombok.Value;
 public class LoremIpsumConfig {
 	@Default private int retries = 0;
 	@Default private int timeoutMillis = 250;
+	@Default private int fixedBigdecimalScale = -1;
 	@Default private ClassBindings classBindings = new ClassBindings();
 }

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
@@ -76,7 +76,7 @@ public abstract class LoremIpsumObjectFactory<T> {
 	}
 
 	@Nullable
-	public abstract T _createLoremIpsumObject(
+	protected abstract T _createLoremIpsumObject(
 			@Nullable Type[] genericMetaData,
 			@Nullable Map<String, ClassUsageInfo<?>> knownInstances,
 			LoremIpsumConfig loremIpsumConfig,

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/LoremIpsumObjectFactory.java
@@ -76,7 +76,7 @@ public abstract class LoremIpsumObjectFactory<T> {
 	}
 
 	@Nullable
-	abstract T _createLoremIpsumObject(
+	public abstract T _createLoremIpsumObject(
 			@Nullable Type[] genericMetaData,
 			@Nullable Map<String, ClassUsageInfo<?>> knownInstances,
 			LoremIpsumConfig loremIpsumConfig,

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomBigDecimalFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomBigDecimalFactory.java
@@ -22,6 +22,8 @@ public class RandomBigDecimalFactory extends LoremIpsumObjectFactory<BigDecimal>
 			final LoremIpsumConfig loremIpsumConfig,
 			@Nullable final List<Exception> exceptions) {
 		LoremIpsumGenerator instance = LoremIpsumGenerator.getInstance();
-		return BigDecimal.valueOf(instance.getRandomInt(), instance.getRandomInt(6));
+		int fixedBigdecimalScaleConfig = loremIpsumConfig.getFixedBigdecimalScale();
+		int scale = fixedBigdecimalScaleConfig < 0 ? instance.getRandomInt(6) : fixedBigdecimalScaleConfig;
+		return BigDecimal.valueOf(instance.getRandomInt(), scale);
 	}
 }

--- a/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomFactoryFactory.java
+++ b/src/main/java/org/bbottema/loremipsumobjects/typefactories/RandomFactoryFactory.java
@@ -29,7 +29,7 @@ public class RandomFactoryFactory<T> extends LoremIpsumObjectFactory<T> {
 	@Nullable
 	@Override
 	@SuppressWarnings("unchecked")
-	T _createLoremIpsumObject(@Nullable Type[] genericMetaData, @Nullable Map<String, ClassUsageInfo<?>> knownInstances, LoremIpsumConfig loremIpsumConfig, @Nullable List<Exception> exceptions) {
+	protected T _createLoremIpsumObject(@Nullable Type[] genericMetaData, @Nullable Map<String, ClassUsageInfo<?>> knownInstances, LoremIpsumConfig loremIpsumConfig, @Nullable List<Exception> exceptions) {
 		return (T) factories.get(RANDOM.nextInt(factories.size()))
 				.createLoremIpsumObject(genericMetaData, knownInstances, loremIpsumConfig, exceptions);
 	}

--- a/src/test/java/org/bbottema/loremipsumobjects/LoremIpsumObjectCreatorTest.java
+++ b/src/test/java/org/bbottema/loremipsumobjects/LoremIpsumObjectCreatorTest.java
@@ -520,6 +520,26 @@ public class LoremIpsumObjectCreatorTest {
 	}
 
 	@Test
+	public void testLorumIpsumBigDecimalFixedScale() {
+		LoremIpsumObjectCreator loremIpsumObjectCreator = new LoremIpsumObjectCreator(LoremIpsumConfig.builder().fixedBigdecimalScale(0).build());
+
+		BigDecimal bigDecimal = loremIpsumObjectCreator.createLoremIpsumObject(BigDecimal.class);
+		assertThat(bigDecimal).isNotNull();
+		assertThat(bigDecimal).isEqualTo(new BigDecimal("111"));
+		System.out.println(bigDecimal);
+
+		loremIpsumObjectCreator = new LoremIpsumObjectCreator(LoremIpsumConfig.builder().fixedBigdecimalScale(1).build());
+		bigDecimal = loremIpsumObjectCreator.createLoremIpsumObject(BigDecimal.class);
+		assertThat(bigDecimal).isNotNull();
+		assertThat(bigDecimal).isEqualTo(new BigDecimal("11.1"));
+
+		loremIpsumObjectCreator = new LoremIpsumObjectCreator(LoremIpsumConfig.builder().fixedBigdecimalScale(2).build());
+		bigDecimal = loremIpsumObjectCreator.createLoremIpsumObject(BigDecimal.class);
+		assertThat(bigDecimal).isNotNull();
+		assertThat(bigDecimal).isEqualTo(new BigDecimal("1.11"));
+	}
+
+	@Test
 	public void testLombokHeavyProcessStatus() {
 		ProcessStatus processStatus = loremIpsumObjectCreator.createLoremIpsumObject(ProcessStatus.class);
 		assertThat(processStatus).isNotNull();


### PR DESCRIPTION
otherwise all custom inherited objectFactories have to be placed under the package org.bbottema.loremipsumobjects.typefactories